### PR TITLE
fix(varname): rename session variable

### DIFF
--- a/src/ios/ASWebAuthSession.m
+++ b/src/ios/ASWebAuthSession.m
@@ -5,7 +5,7 @@
 
 #import <Cordova/CDVAvailability.h>
 
-ASWebAuthenticationSession *_authenticationVC;
+ASWebAuthenticationSession *_webAuthenticationSessionVC;
 
 
 @implementation ASWebAuthSession;
@@ -23,7 +23,7 @@ ASWebAuthenticationSession *_authenticationVC;
                                    callbackURLScheme:redirectScheme
                                    completionHandler:^(NSURL * _Nullable callbackURL,
                                                        NSError * _Nullable error) {
-                                       _authenticationVC = nil;
+                                       _webAuthenticationSessionVC = nil;
                                        CDVPluginResult *result;
                                        if (callbackURL) {
                                            result = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString: callbackURL.absoluteString];
@@ -33,7 +33,7 @@ ASWebAuthenticationSession *_authenticationVC;
                                        }
                                        [self.commandDelegate sendPluginResult:result callbackId:command.callbackId];
                                    }];
-        _authenticationVC = authenticationVC;
+        _webAuthenticationSessionVC = authenticationVC;
         [authenticationVC start];
     }
 }


### PR DESCRIPTION
Will avoid duplicate symbols error when used with cordova-plugin-sfauthenticationsession

If you are also using the `cordova-plugin-sfauthenticationsession` you will get an error for duplicate symbols. It was fixed in another fork but unfortunately that PR never got merged. https://github.com/RasimKanca/cordova-plugin-aswebauthenticationsession/commit/9b12c3479050683ccc12e6d37db930283b497ce4

https://github.com/mochini/cordova-plugin-aswebauthenticationsession/pull/2